### PR TITLE
Removed most derecation warnings for Julia v0.4

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.3-
 OpenCL
+Compat

--- a/examples/clblasSgemmRandomBufferFuture.jl
+++ b/examples/clblasSgemmRandomBufferFuture.jl
@@ -1,5 +1,6 @@
 import CLBLAS
 import OpenCL
+using Compat
 
     const clblas = CLBLAS
     clblas.setup()
@@ -17,7 +18,7 @@ import OpenCL
     matC = clblas.fetch(C)
 
     data = (5.0*matA*matB) + (2.0*matC)
-    future = clblas.clblasSgemm(uint32(0), uint32(0), alpha, A, B, beta, C)
+    future = clblas.clblasSgemm(UInt32(0), UInt32(0), alpha, A, B, beta, C)
 
     result = fetch(future)
     println(result)

--- a/examples/clblasSgemm_future.jl
+++ b/examples/clblasSgemm_future.jl
@@ -12,7 +12,7 @@ import OpenCL
 
     data = (5.0*A*B) + (2.0*C)
 
-    future = clblas.clblasSgemm(uint32(0), uint32(0), alpha, A, B, beta, C)
+    future = clblas.clblasSgemm(UInt32(0), UInt32(0), alpha, A, B, beta, C)
 
     result = fetch(future)
     println(result)

--- a/examples/performance/nvidia-gemm.jl
+++ b/examples/performance/nvidia-gemm.jl
@@ -26,9 +26,9 @@ import OpenCL
     sizeC = Ndim * Mdim
 
     # Number of elements in the matrix
-    h_A = fill(float32(AVAL), sizeA)
-    h_B = fill(float32(BVAL), sizeB)
-    h_C = fill(float32(CVAL), sizeC)
+    h_A = fill(Float32(AVAL), sizeA)
+    h_B = fill(Float32(BVAL), sizeB)
+    h_C = fill(Float32(CVAL), sizeC)
 
     data = reshape(h_A, Ndim, Pdim)*reshape(h_B, Pdim, Mdim) * 5 + 2.0*reshape(h_C, Ndim, Mdim)
 

--- a/examples/practice/RandomMatrixMul_GPUvsCPU.jl
+++ b/examples/practice/RandomMatrixMul_GPUvsCPU.jl
@@ -116,8 +116,8 @@ function runTimes(num::Int, device=nothing, context=nothing, queue=nothing, mmul
             device, context, queue = clblas.get_next_compute_context()
         end
 
-        alpha = float32(5)
-        beta  = float32(2)
+        alpha = Float32(5)
+        beta  = Float32(2)
 
         matSizes = generateAlmostSqRandomMatrixSize(num)
 

--- a/src/CLBLAS.jl
+++ b/src/CLBLAS.jl
@@ -1,4 +1,3 @@
-require("OpenCL")
 
 module CLBLAS
 
@@ -6,6 +5,8 @@ module CLBLAS
    import OpenCL
    const cl = OpenCL
    const RAND_FUNC = "rand_cl"
+
+   using Compat
 
    include("util/enum.jl")
    include("constants.jl")

--- a/src/L1/SCAL.jl
+++ b/src/L1/SCAL.jl
@@ -28,7 +28,7 @@ const cl = OpenCL
 
 macro blas_scal(func, argType1, argType2)
      quote
-         function $(esc(func))( future_or_data::Union($argType1, Future), alpha::$argType2)
+         function $(esc(func))( future_or_data::@compat(Union{$argType1, Future}), alpha::$argType2)
              future = to_futures(future_or_data)[1]
              req_num_events, events = getEvents(future)
              future_to_return = Future(future.ctx, future.queue, future.mem, future.dims)

--- a/src/L3/GEMM.jl
+++ b/src/L3/GEMM.jl
@@ -1,21 +1,21 @@
 import OpenCL
 const cl = OpenCL
 
-@api.blas_func(clblasSgemm, (Uint32, Uint32, Uint32,
+@api.blas_func(clblasSgemm, (UInt32, UInt32, UInt32,
                              Csize_t, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
                              cl.CL_mem, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
                              cl.CL_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
                              Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasSgemm, (Uint32, Uint32, Uint32,
+@api.blas_func2(clblasSgemm, (UInt32, UInt32, UInt32,
                 Csize_t, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
                 cl.CL_mem, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t))
 
 macro blas_gemm(func, arrType, mulType)
     quote
-        function $(esc(func))( at::Uint32, bt::Uint32,
-                alpha::$mulType, A::Union($arrType, Future),
-                B::Union($arrType, Future), beta::$mulType, C::Union($arrType, Future))
+        function $(esc(func))( at::UInt32, bt::UInt32,
+                alpha::$mulType, A::@compat(Union{$arrType, Future}),
+                B::@compat(Union{$arrType, Future}), beta::$mulType, C::@compat(Union{$arrType, Future}))
 
 
             futures = to_futures(A, B, C)
@@ -49,32 +49,32 @@ end
 
 @blas_gemm(clblasSgemm, Array{cl.CL_float}, cl.CL_float)
 
-@api.blas_func(clblasDgemm, (Uint32, Uint32, Uint32,
+@api.blas_func(clblasDgemm, (UInt32, UInt32, UInt32,
               Csize_t, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
               cl.CL_mem, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
               cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
               Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasDgemm, (Uint32, Uint32, Uint32,
+@api.blas_func2(clblasDgemm, (UInt32, UInt32, UInt32,
               Csize_t, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
               cl.CL_mem, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t))
 
-@api.blas_func(clblasCgemm, (Uint32, Uint32, Uint32,
+@api.blas_func(clblasCgemm, (UInt32, UInt32, UInt32,
             Csize_t, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
             cl.CL_mem, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
             cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
             Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasCgemm, (Uint32, Uint32, Uint32,
+@api.blas_func2(clblasCgemm, (UInt32, UInt32, UInt32,
             Csize_t, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
             cl.CL_mem, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t))
 
-@api.blas_func(clblasZgemm, (Uint32, Uint32, Uint32,
+@api.blas_func(clblasZgemm, (UInt32, UInt32, UInt32,
               Csize_t, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
               cl.CL_mem, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
               cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
               Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasZgemm, (Uint32, Uint32, Uint32,
+@api.blas_func2(clblasZgemm, (UInt32, UInt32, UInt32,
               Csize_t, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
               cl.CL_mem, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t))

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,6 +2,7 @@ module api
 
 import OpenCL
 const cl = OpenCL
+using Compat
 
 @unix_only const libCLBLAS = "libclBLAS"
 @windows_only const libCLBLAS = "clBLAS"
@@ -28,7 +29,7 @@ const cl = OpenCL
                                for (i, T) in enumerate(arg_types.args)]
 
         quote
-            function $(esc(func))($(args_in...), inQueues::Vector{cl.CmdQueue}, inEvents::Union(Vector{cl.CL_event}, Nothing)=nothing)
+            function $(esc(func))($(args_in...), inQueues::Vector{cl.CmdQueue}, inEvents::@compat(Union{Vector{cl.CL_event}, Void})=nothing)
                 local ctx = cl.info(inQueues[1], :context)
                 local num_queues = length(inQueues)
                 

--- a/src/future.jl
+++ b/src/future.jl
@@ -1,5 +1,6 @@
 import OpenCL
 const cl = OpenCL
+using Compat
 
 type Future
    ctx::cl.Context
@@ -8,9 +9,9 @@ type Future
    #Dimensions are important to read the result back.
    dims::Tuple
    # Vector because we would like to keep the pointer around
-   event::Union(Vector{cl.CL_event}, Nothing)
+   event::@compat(Union{Vector{cl.CL_event}, Void})
    # kept around for profiling
-   actualEvent::Union(cl.CLEvent, Nothing)
+   actualEvent::@compat(Union{cl.CLEvent, Void})
 
    function Future{T}(ctx::cl.Context, queue::cl.CmdQueue, data::Array{T})
       #Sync call to create buffer
@@ -46,7 +47,7 @@ function getEvents(futures::Array{Future, 1})
    return (req_num_events, events)
 end
 
-function first_future(futures::Union(Array, Future)...)
+function first_future(futures::@compat(Union{Array, Future})...)
     for i in 1:length(futures)
         local future = futures[i]
         if typeof(future) == Future
@@ -56,7 +57,7 @@ function first_future(futures::Union(Array, Future)...)
     return nothing
 end
 
-function to_futures(inputs::Union(Array, Future)...)
+function to_futures(inputs::@compat(Union{Array, Future})...)
     local ctx = nothing
     local queue = nothing
     local mem = nothing

--- a/src/rand.jl
+++ b/src/rand.jl
@@ -32,7 +32,7 @@ function randBuf(dims::Int...; ctx=nothing, queue=nothing)
 
     kernel = randByCtx(ctx)
 
-    seed = uint32(time_ns())
+    seed = floor(UInt32, time_ns() >> 32)
     cl.set_arg!(kernel, 1, seed)
     globalMem = cl.Buffer(Float32, ctx, :rw, dim)
     cl.set_arg!(kernel, 2, globalMem)

--- a/src/util/enum.jl
+++ b/src/util/enum.jl
@@ -1,6 +1,7 @@
 #
 #  This code has been taken https://raw.github.com/JuliaLang/julia/jn/enum2/base/enum.jl
 #
+
 abstract Enum
 
 Base.typemin{T<:Enum}(x::Type{T}) = T(0)
@@ -44,7 +45,7 @@ Base.names{T<:Enum}(x::Type{T}) = [s[1] for s in T]
 
 macro enum(T,syms...)
     assert(!isempty(syms))
-    vals = Array((Symbol,Int64),0)
+    vals = Array(@compat(Tuple{Symbol,Int64}),0)
     i::Int64 = -1
     lo::Int64 = typemax(Int64)
     hi::Int64 = typemin(Int64)
@@ -84,10 +85,10 @@ macro enum(T,syms...)
             enumT = Int64
         end
     else
-        if max(abs(lo),abs(hi)) < typemax(Uint32)
-            enumT = Uint32
+        if max(abs(lo),abs(hi)) < typemax(UInt32)
+            enumT = UInt32
         else
-            enumT = Uint64
+            enumT = UInt64
         end
     end
     blk = quote
@@ -130,9 +131,9 @@ Base.show(io::IO, x::Type{EnumMask}) = print(io, "EnumMask")
 
 macro enum_mask(T,syms...)
     if length(syms) <= 32
-        enumT = Uint32
+        enumT = UInt32
     elseif length(syms) <= 64
-        enumT = Uint64
+        enumT = UInt64
     else
         error("too many symbols for @enum_mask")
     end


### PR DESCRIPTION
Most of the code works fine with Julia 0.4, but output is full of annoying deprecation warnings. In this PR I tried to remove as much of them as possible. Note, that some code in `examples/` folder has errors (in usage, not in the library code itself) and requires deeper inspection, which is out of my competence. 