### PR TITLE
using `Ptr{T}` without specifying `T` was causing `convert()` error in ...

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -40,7 +40,7 @@ using Compat
                     events = inEvents
                 end 
                 
-                local queues = Ptr[ queue.id for queue in inQueues]
+                local queues = cl.CL_command_queue[ queue.id for queue in inQueues ]
                 
                 local event = cl.UserEvent(ctx, retain=true)
                 local ptrEvent = [event.id]


### PR DESCRIPTION
... `@blas_func2`

Changing `Ptr` -> `Ptr{Void}` would have also worked, but I like this variant better because it is more specific.