### PR TITLE
Api2 fix

### DIFF
--- a/src/L3/GEMM.jl
+++ b/src/L3/GEMM.jl
@@ -88,7 +88,7 @@ for (func, typ) in [(:clblasSgemm, cl.CL_float),
                     (:clblasCgemm, CL_float2),
                     (:clblasZgemm, CL_double2)]
     
-    @eval @api2.blasfun $func(order::UInt32,
+    @eval @api2.blasfun $func(order::clblasOrder,
                               transA::clblasTranspose, transB::clblasTranspose,
                               M::Csize_t, N::Csize_t, K::Csize_t,
                               alpha::$typ,
@@ -102,7 +102,7 @@ for (func, typ) in [(:clblasSgemm, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::UInt32,
+    @eval @api2.blasfun2 $func(order::clblasOrder,
                                transA::clblasTranspose, transB::clblasTranspose,
                                M::Csize_t, N::Csize_t, K::Csize_t,
                                alpha::$typ,

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,14 +1,7 @@
 import OpenCL
 
-immutable CL_float2
-   n1::OpenCL.CL_float
-   n2::OpenCL.CL_float
-end
-
-immutable CL_double2
-   n1::OpenCL.CL_double
-   n2::OpenCL.CL_double
-end
+typealias CL_float2 Complex64
+typealias CL_double2 Complex128
 
 typealias FloatComplex CL_float2
 typealias DoubleComplex CL_double2


### PR DESCRIPTION
Make api2 slightly more lenient with the input types: accepts any `Number` instead of `Csizet`, and any `Real` instead of `CL_float` and `CL_double`. Also cleaner handling of enums.