### PR TITLE
cl.release! was deprecated in OpenCL.jl PR 80

### DIFF
--- a/src/CLBLAS.jl
+++ b/src/CLBLAS.jl
@@ -93,8 +93,8 @@ module CLBLAS
    function release!(compute_context_holder::Vector{Tuple})
        for (dev, ctx, queue) in compute_context_holder
            try
-              cl.release!(queue)
-              cl.release!(ctx)
+              finalize(queue)
+              finalize(ctx)
            catch err
               println(err)
               continue


### PR DESCRIPTION
needed because of https://github.com/JuliaGPU/OpenCL.jl/pull/80