### PR TITLE
Removed internal modules, added some HL functions

### DIFF
--- a/src/CLBLAS.jl
+++ b/src/CLBLAS.jl
@@ -15,12 +15,14 @@ module CLBLAS
    include("constants.jl")
    include("future.jl")
    include("api.jl")
-   include("api2.jl")
+   include("macros.jl")   
    include("rand.jl")
 
    include("L1/L1.jl")
    include("L2/L2.jl")
    include("L3/L3.jl")
+
+   include("highlevel.jl")
 
    LocalMem{T}(::Type{T}, len::Integer) = begin
          @assert len > 0

--- a/src/L1/ASUM.jl
+++ b/src/L1/ASUM.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasSasum, :clblasDasum, :clblasScasum, :clblasDzsum]
-    @eval @api2.blasfun $func(N::Csize_t, asum::cl.CL_mem, offAsum::Csize_t,
+    @eval @blasfun $func(N::Csize_t, asum::cl.CL_mem, offAsum::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               scratch_buff::cl.CL_mem,
                               n_queues::cl.CL_uint,
@@ -9,7 +9,7 @@ for func in [:clblasSasum, :clblasDasum, :clblasScasum, :clblasDzsum]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
     
-    @eval @api2.blasfun2 $func(N::Csize_t, asum::cl.CL_mem, offAsum::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t, asum::cl.CL_mem, offAsum::Csize_t,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,
                                scratch_buff::cl.CL_mem)
 end

--- a/src/L1/AXPY.jl
+++ b/src/L1/AXPY.jl
@@ -1,5 +1,5 @@
 
-@api2.blasfun clblasSaxpy(n::Csize_t, alpha::cl.CL_float,
+@blasfun clblasSaxpy(n::Csize_t, alpha::cl.CL_float,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           n_queues::cl.CL_uint,
@@ -8,12 +8,12 @@
                           event_wait_list::Ptr{cl.CL_event},
                           events::Ptr{cl.CL_event})
 
-@api2.blasfun2 clblasSaxpy(n::Csize_t, alpha::cl.CL_float,
+@blasfun2 clblasSaxpy(n::Csize_t, alpha::cl.CL_float,
                            X::cl.CL_mem, offx::Csize_t, incx::Cint,
                            Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 
 
-@api2.blasfun clblasDaxpy(n::Csize_t, alpha::cl.CL_double,
+@blasfun clblasDaxpy(n::Csize_t, alpha::cl.CL_double,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           n_queues::cl.CL_uint,
@@ -22,12 +22,12 @@
                           event_wait_list::Ptr{cl.CL_event},
                           events::Ptr{cl.CL_event})
 
-@api2.blasfun2 clblasDaxpy(n::Csize_t, alpha::cl.CL_double,
+@blasfun2 clblasDaxpy(n::Csize_t, alpha::cl.CL_double,
                            X::cl.CL_mem, offx::Csize_t, incx::Cint,
                            Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 
 
-@api2.blasfun clblasCaxpy(n::Csize_t, alpha::CL_float2,
+@blasfun clblasCaxpy(n::Csize_t, alpha::CL_float2,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           n_queues::cl.CL_uint,
@@ -36,12 +36,12 @@
                           event_wait_list::Ptr{cl.CL_event},
                           events::Ptr{cl.CL_event})
 
-@api2.blasfun2 clblasCaxpy(n::Csize_t, alpha::CL_float2,
+@blasfun2 clblasCaxpy(n::Csize_t, alpha::CL_float2,
                            X::cl.CL_mem, offx::Csize_t, incx::Cint,
                            Y::cl.CL_mem, offy::Csize_t, incy::Cint)
                            
 
-@api2.blasfun clblasZaxpy(n::Csize_t, alpha::CL_double2,
+@blasfun clblasZaxpy(n::Csize_t, alpha::CL_double2,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           n_queues::cl.CL_uint,
@@ -50,7 +50,7 @@
                           event_wait_list::Ptr{cl.CL_event},
                           events::Ptr{cl.CL_event})
 
-@api2.blasfun2 clblasZaxpy(n::Csize_t, alpha::CL_double2,
+@blasfun2 clblasZaxpy(n::Csize_t, alpha::CL_double2,
                            X::cl.CL_mem, offx::Csize_t, incx::Cint,
                            Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 

--- a/src/L1/COPY.jl
+++ b/src/L1/COPY.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasScopy, :clblasDcopy, :clblasCcopy, :clblasZcopy]
-    @eval @api2.blasfun $func(N::Csize_t,
+    @eval @blasfun $func(N::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                               n_queues::cl.CL_uint,
@@ -8,7 +8,7 @@ for func in [:clblasScopy, :clblasDcopy, :clblasCcopy, :clblasZcopy]
                               n_events_in_wait_list::cl.CL_uint,
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
-    @eval @api2.blasfun2 $func(N::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 end

--- a/src/L1/DOT.jl
+++ b/src/L1/DOT.jl
@@ -3,7 +3,7 @@ for func in [:clblasSdot, :clblasDdot,
              :clblasCdotu, :clblasZdotu,
              :clblasCdotc, :clblasZdotc]
     
-    @eval @api2.blasfun $func(N::Csize_t, dot_product::cl.CL_mem, offDP::Csize_t,
+    @eval @blasfun $func(N::Csize_t, dot_product::cl.CL_mem, offDP::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                               scratch_buff::cl.CL_mem,
@@ -12,7 +12,7 @@ for func in [:clblasSdot, :clblasDdot,
                               n_events_in_wait_list::cl.CL_uint,
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
-    @eval @api2.blasfun2 $func(N::Csize_t, dot_product::cl.CL_mem, offDP::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t, dot_product::cl.CL_mem, offDP::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                               scratch_buff::cl.CL_mem)

--- a/src/L1/NRM2.jl
+++ b/src/L1/NRM2.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasSnrm2, :clblasDnrm2, :clblasScnrm2, :clblasDznrm2]
-    @eval @api2.blasfun $func(N::Csize_t, NRM2::cl.CL_mem, offNRM2::Csize_t,
+    @eval @blasfun $func(N::Csize_t, NRM2::cl.CL_mem, offNRM2::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               scratch_buff::cl.CL_mem,
                               n_queues::cl.CL_uint,
@@ -8,7 +8,7 @@ for func in [:clblasSnrm2, :clblasDnrm2, :clblasScnrm2, :clblasDznrm2]
                               n_events_in_wait_list::cl.CL_uint,
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
-    @eval @api2.blasfun2 $func(N::Csize_t, NRM2::cl.CL_mem, offNRM2::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t, NRM2::cl.CL_mem, offNRM2::Csize_t,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,
                                scratch_buff::cl.CL_mem)
 end

--- a/src/L1/ROT.jl
+++ b/src/L1/ROT.jl
@@ -1,5 +1,5 @@
 
-@api2.blasfun clblasSrot(N::Csize_t,
+@blasfun clblasSrot(N::Csize_t,
                          X::cl.CL_mem, offx::Csize_t, incx::Cint,
                          Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                          C::cl.CL_float, S::cl.CL_float,
@@ -9,13 +9,13 @@
                          event_wait_list::Ptr{cl.CL_event},
                          events::Ptr{cl.CL_event})
                          
-@api2.blasfun2 clblasSrot(N::Csize_t,
+@blasfun2 clblasSrot(N::Csize_t,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           C::cl.CL_float, S::cl.CL_float)
                           
 
-@api2.blasfun clblasDrot(N::Csize_t,
+@blasfun clblasDrot(N::Csize_t,
                          X::cl.CL_mem, offx::Csize_t, incx::Cint,
                          Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                          C::cl.CL_double, S::cl.CL_double,
@@ -25,12 +25,12 @@
                          event_wait_list::Ptr{cl.CL_event},
                          events::Ptr{cl.CL_event})
 
-@api2.blasfun2 clblasDrot(N::Csize_t,
+@blasfun2 clblasDrot(N::Csize_t,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           C::cl.CL_double, S::cl.CL_double)
                           
-@api2.blasfun clblasCsrot(N::Csize_t,
+@blasfun clblasCsrot(N::Csize_t,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           C::cl.CL_float, S::cl.CL_float,
@@ -40,13 +40,13 @@
                           event_wait_list::Ptr{cl.CL_event},
                           events::Ptr{cl.CL_event})
                          
-@api2.blasfun2 clblasCrot(N::Csize_t,
+@blasfun2 clblasCrot(N::Csize_t,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           C::cl.CL_float, S::cl.CL_float)
 
 
-@api2.blasfun clblasZdrot(N::Csize_t,
+@blasfun clblasZdrot(N::Csize_t,
                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
                           Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                           C::cl.CL_double, S::cl.CL_double,
@@ -56,7 +56,7 @@
                           event_wait_list::Ptr{cl.CL_event},
                           events::Ptr{cl.CL_event})
 
-@api2.blasfun2 clblasZdrot(N::Csize_t,
+@blasfun2 clblasZdrot(N::Csize_t,
                            X::cl.CL_mem, offx::Csize_t, incx::Cint,
                            Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                            C::cl.CL_double, S::cl.CL_double)

--- a/src/L1/ROTG.jl
+++ b/src/L1/ROTG.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasSrotg, :clblasDrotg, :clblasCrotg, :clblasZrotg]
     
-    @eval @api2.blasfun $func(CA::cl.CL_mem, offCA::Csize_t,
+    @eval @blasfun $func(CA::cl.CL_mem, offCA::Csize_t,
                               CB::cl.CL_mem, offCB::Csize_t,
                               C::cl.CL_mem, offC::Csize_t,
                               S::cl.CL_mem, offS::Csize_t,
@@ -11,7 +11,7 @@ for func in [:clblasSrotg, :clblasDrotg, :clblasCrotg, :clblasZrotg]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(CA::cl.CL_mem, offCA::Csize_t,
+    @eval @blasfun2 $func(CA::cl.CL_mem, offCA::Csize_t,
                                CB::cl.CL_mem, offCB::Csize_t,
                                C::cl.CL_mem, offC::Csize_t,
                                S::cl.CL_mem, offS::Csize_t)

--- a/src/L1/ROTM.jl
+++ b/src/L1/ROTM.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasSrotm, :clblasDrotm]
-    @eval @api2.blasfun $func(N::Csize_t,
+    @eval @blasfun $func(N::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                               SPARAM::cl.CL_mem, offSparam::Csize_t,
@@ -10,7 +10,7 @@ for func in [:clblasSrotm, :clblasDrotm]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
     
-    @eval @api2.blasfun2 $func(N::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,
                                Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                                SPARAM::cl.CL_mem, offSparam::Csize_t)

--- a/src/L1/ROTMG.jl
+++ b/src/L1/ROTMG.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasSrotmg, :clblasDrotmg]
-    @eval @api2.blasfun $func(SD1::cl.CL_mem, offSD1::Csize_t,
+    @eval @blasfun $func(SD1::cl.CL_mem, offSD1::Csize_t,
                               SD2::cl.CL_mem, offSD2::Csize_t,
                               SX1::cl.CL_mem, offSX1::Csize_t,
                               SY1::cl.CL_mem, offSY1::Csize_t,
@@ -11,7 +11,7 @@ for func in [:clblasSrotmg, :clblasDrotmg]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(SD1::cl.CL_mem, offSD1::Csize_t,
+    @eval @blasfun2 $func(SD1::cl.CL_mem, offSD1::Csize_t,
                                SD2::cl.CL_mem, offSD2::Csize_t,
                                SX1::cl.CL_mem, offSX1::Csize_t,
                                SY1::cl.CL_mem, offSY1::Csize_t,

--- a/src/L1/SCAL.jl
+++ b/src/L1/SCAL.jl
@@ -57,7 +57,7 @@ for (func, typ) in [(:clblasSscal, cl.CL_float),
                     (:clblasCscal, CL_float2),
                     (:clblasZscal, CL_double2)]
     
-    @eval @api2.blasfun $func(N::Csize_t, alpha::CL_double2,
+    @eval @blasfun $func(N::Csize_t, alpha::CL_double2,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               n_queues::cl.CL_uint,
                               queues::Ptr{cl.CL_command_queue},
@@ -65,7 +65,7 @@ for (func, typ) in [(:clblasSscal, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(N::Csize_t, alpha::CL_double2,
+    @eval @blasfun2 $func(N::Csize_t, alpha::CL_double2,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint)
     
 end

--- a/src/L1/SSCAL.jl
+++ b/src/L1/SSCAL.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasCsscal, cl.CL_float),
                     (:clblasZdscal, cl.CL_double)]
     
-    @eval @api2.blasfun $func(N::Csize_t, alpha::$typ,
+    @eval @blasfun $func(N::Csize_t, alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               n_queues::cl.CL_uint,
                               queues::Ptr{cl.CL_command_queue},
@@ -10,7 +10,7 @@ for (func, typ) in [(:clblasCsscal, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(N::Csize_t, alpha::$typ,
+    @eval @blasfun2 $func(N::Csize_t, alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint)
     
 end

--- a/src/L1/SWAP.jl
+++ b/src/L1/SWAP.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasSswap, :clblasDswap, :clblasCswap, :clblasZswap]
-    @eval @api2.blasfun $func(N::Csize_t,
+    @eval @blasfun $func(N::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint,
                               n_queues::cl.CL_uint,
@@ -9,7 +9,7 @@ for func in [:clblasSswap, :clblasDswap, :clblasCswap, :clblasZswap]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(N::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,
                                Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 end

--- a/src/L1/iAMAX.jl
+++ b/src/L1/iAMAX.jl
@@ -1,6 +1,6 @@
 
 for func in [:clblasiSamax, :clblasiDamax, :clblasiCamax, :clblasiZamax]
-    @eval @api2.blasfun $func(N::Csize_t,
+    @eval @blasfun $func(N::Csize_t,
                               iMax::cl.CL_mem, offiMax::Csize_t,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               scratch_buff::cl.CL_mem,
@@ -10,7 +10,7 @@ for func in [:clblasiSamax, :clblasiDamax, :clblasiCamax, :clblasiZamax]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(N::Csize_t,
+    @eval @blasfun2 $func(N::Csize_t,
                                iMax::cl.CL_mem, offiMax::Csize_t,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,
                                scratch_buff::cl.CL_mem)

--- a/src/L2/GBMV.jl
+++ b/src/L2/GBMV.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasSgbmv, cl.CL_float),
                     (:clblasCgbmv, CL_float2),
                     (:clblasZgbmv, CL_double2)]
 
-    @eval @api2.blasfun $func(order::clblasOrder, trans::clblasTranspose,
+    @eval @blasfun $func(order::clblasOrder, trans::clblasTranspose,
                               M::Csize_t, N::Csize_t,
                               KL::Csize_t, KU::Csize_t,
                               alpha::$typ,
@@ -18,7 +18,7 @@ for (func, typ) in [(:clblasSgbmv, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, trans::clblasTranspose,
+    @eval @blasfun2 $func(order::clblasOrder, trans::clblasTranspose,
                                M::Csize_t, N::Csize_t,
                                KL::Csize_t, KU::Csize_t,
                                alpha::$typ,

--- a/src/L2/GEMV.jl
+++ b/src/L2/GEMV.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasSgemv, cl.CL_float),
                     (:clblasCgemv, CL_float2),
                     (:clblasZgemv, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, transA::clblasTranspose,
+    @eval @blasfun $func(order::clblasOrder, transA::clblasTranspose,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
                               A::cl.CL_mem, offA::Csize_t, lda::Csize_t,
@@ -17,7 +17,7 @@ for (func, typ) in [(:clblasSgemv, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, transA::clblasTranspose,
+    @eval @blasfun2 $func(order::clblasOrder, transA::clblasTranspose,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
                               A::cl.CL_mem, offA::Csize_t, lda::Csize_t,

--- a/src/L2/GER.jl
+++ b/src/L2/GER.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasDger, cl.CL_float),
                     (:clblasDger, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder,
+    @eval @blasfun $func(order::clblasOrder,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -14,7 +14,7 @@ for (func, typ) in [(:clblasDger, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder,
+    @eval @blasfun2 $func(order::clblasOrder,
                                M::Csize_t, N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/GERC.jl
+++ b/src/L2/GERC.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasCgerc, CL_float2),
                     (:clblasZgerc, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder,
+    @eval @blasfun $func(order::clblasOrder,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -14,7 +14,7 @@ for (func, typ) in [(:clblasCgerc, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder,
+    @eval @blasfun2 $func(order::clblasOrder,
                                M::Csize_t, N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/GERU.jl
+++ b/src/L2/GERU.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasCgeru, CL_float2),
                     (:clblasZgeru, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder,
+    @eval @blasfun $func(order::clblasOrder,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -14,7 +14,7 @@ for (func, typ) in [(:clblasCgeru, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder,
+    @eval @blasfun2 $func(order::clblasOrder,
                                M::Csize_t, N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/HBMV.jl
+++ b/src/L2/HBMV.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasChbmv, CL_float2),
                     (:clblasZhbmv, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t, K::Csize_t,
                               alpha::$typ,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasChbmv, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t, K::Csize_t,
                                alpha::$typ,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L2/HEMV.jl
+++ b/src/L2/HEMV.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasChemv, CL_float2),
                     (:clblasZhemv, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasChemv, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L2/HER.jl
+++ b/src/L2/HER.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasCher, CL_float2),
                     (:clblasZher, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::cl.CL_double,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -13,7 +13,7 @@ for (func, typ) in [(:clblasCher, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::cl.CL_double,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/HER2.jl
+++ b/src/L2/HER2.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasCher2, CL_float2),
                     (:clblasZher2, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -14,7 +14,7 @@ for (func, typ) in [(:clblasCher2, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/HPMV.jl
+++ b/src/L2/HPMV.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasChpmv, CL_float2),
                     (:clblasChpmv, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                AP::cl.CL_mem, offa::Csize_t,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasChpmv, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                AP::cl.CL_mem, offa::Csize_t,

--- a/src/L2/HPR.jl
+++ b/src/L2/HPR.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasChpr, cl.CL_float),
                     (:clblasZhpr, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -13,7 +13,7 @@ for (func, typ) in [(:clblasChpr, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/HPR2.jl
+++ b/src/L2/HPR2.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasChpr2, CL_float2),
                     (:clblasZhpr2, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t, alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
                               Y::cl.CL_mem, offy::Csize_t, incy::Cint,
@@ -13,7 +13,7 @@ for (func, typ) in [(:clblasChpr2, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t, alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,
                                Y::cl.CL_mem, offy::Csize_t, incy::Cint,

--- a/src/L2/SBMV.jl
+++ b/src/L2/SBMV.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasSsbmv, cl.CL_float),
                     (:clblasDsbmv, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t, K::Csize_t,
                               alpha::$typ,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasSsbmv, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t, K::Csize_t,
                                alpha::$typ,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L2/SPMV.jl
+++ b/src/L2/SPMV.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasSspmv, cl.CL_float),
                     (:clblasDspmv, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               AP::cl.CL_mem, offa::Csize_t,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasSspmv, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                AP::cl.CL_mem, offa::Csize_t,

--- a/src/L2/SPR.jl
+++ b/src/L2/SPR.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasSspr, cl.CL_float),
                     (:clblasDspr, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -13,7 +13,7 @@ for (func, typ) in [(:clblasSspr, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/SPR2.jl
+++ b/src/L2/SPR2.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasSspr2, cl.CL_float),
                     (:clblasDspr2, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -14,7 +14,7 @@ for (func, typ) in [(:clblasSspr2, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/SYMV.jl
+++ b/src/L2/SYMV.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasSsymv, cl.CL_float),
                     (:clblasDsymv, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               A::cl.CL_mem, offA::Csize_t, lda::Csize_t,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasSsymv, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                A::cl.CL_mem, offA::Csize_t, lda::Csize_t,

--- a/src/L2/SYR.jl
+++ b/src/L2/SYR.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasSsyr, cl.CL_float),
                     (:clblasDsyr, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -13,7 +13,7 @@ for (func, typ) in [(:clblasSsyr, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/SYR2.jl
+++ b/src/L2/SYR2.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasDsyr2, cl.CL_float),
                     (:clblasDsyr2, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               N::Csize_t,
                               alpha::$typ,
                               X::cl.CL_mem, offx::Csize_t, incx::Cint,
@@ -14,7 +14,7 @@ for (func, typ) in [(:clblasDsyr2, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                N::Csize_t,
                                alpha::$typ,
                                X::cl.CL_mem, offx::Csize_t, incx::Cint,

--- a/src/L2/TBMV.jl
+++ b/src/L2/TBMV.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasStbmv, :clblasDtbmv, :clblasCtbmv, :clblasZtbmv]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose, diag::clblasDiag,
                               N::Csize_t, K::Csize_t,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -13,7 +13,7 @@ for func in [:clblasStbmv, :clblasDtbmv, :clblasCtbmv, :clblasZtbmv]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose, diag::clblasDiag,
                                N::Csize_t, K::Csize_t,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L2/TBSV.jl
+++ b/src/L2/TBSV.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasStbmv, :clblasDtbmv, :clblasCtbmv, :clblasZtbmv]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose, diag::clblasDiag,
                               N::Csize_t, K::Csize_t,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -13,7 +13,7 @@ for func in [:clblasStbmv, :clblasDtbmv, :clblasCtbmv, :clblasZtbmv]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose, diag::clblasDiag,
                                N::Csize_t, K::Csize_t,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L2/TPMV.jl
+++ b/src/L2/TPMV.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasStpmv, :clblasDtpmv, :clblasCtpmv, :clblasZtpmv]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose, diag::clblasDiag,
                               N::Csize_t,
                               AP::cl.CL_mem, offa::Csize_t,
@@ -13,7 +13,7 @@ for func in [:clblasStpmv, :clblasDtpmv, :clblasCtpmv, :clblasZtpmv]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose, diag::clblasDiag,
                                N::Csize_t,
                                AP::cl.CL_mem, offa::Csize_t,

--- a/src/L2/TPSV.jl
+++ b/src/L2/TPSV.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasStpsv, :clblasDtpsv, :clblasCtpsv, :clblasZtpsv]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose, diag::clblasDiag,
                               N::Csize_t,
                               A::cl.CL_mem, offa::Csize_t,
@@ -12,7 +12,7 @@ for func in [:clblasStpsv, :clblasDtpsv, :clblasCtpsv, :clblasZtpsv]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose, diag::clblasDiag,
                                N::Csize_t,
                                A::cl.CL_mem, offa::Csize_t,

--- a/src/L2/TRMV.jl
+++ b/src/L2/TRMV.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasStrmv, :clblasDtrmv, :clblasCtrmv, :clblasZtrmv]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose, diag::clblasDiag,
                               N::Csize_t,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -13,7 +13,7 @@ for func in [:clblasStrmv, :clblasDtrmv, :clblasCtrmv, :clblasZtrmv]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose, diag::clblasDiag,
                                N::Csize_t,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L2/TRSV.jl
+++ b/src/L2/TRSV.jl
@@ -1,7 +1,7 @@
 
 for func in [:clblasStrsv, :clblasDtrsv, :clblasCtrsv, :clblasZtrsv]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose, diag::clblasDiag,
                               N::Csize_t,
                               A::cl.CL_mem, offa::Csize_t, lda::Csize_t,
@@ -12,7 +12,7 @@ for func in [:clblasStrsv, :clblasDtrsv, :clblasCtrsv, :clblasZtrsv]
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose, diag::clblasDiag,
                                N::Csize_t,
                                A::cl.CL_mem, offa::Csize_t, lda::Csize_t,

--- a/src/L3/GEMM.jl
+++ b/src/L3/GEMM.jl
@@ -1,83 +1,83 @@
 import OpenCL
 const cl = OpenCL
 
-@api.blas_func(clblasSgemm, (UInt32, UInt32, UInt32,
-                             Csize_t, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
-                             cl.CL_mem, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
-                             cl.CL_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
-                             Ptr{cl.CL_event}))
+## @api.blas_func(clblasSgemm, (UInt32, UInt32, UInt32,
+##                              Csize_t, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
+##                              cl.CL_mem, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
+##                              cl.CL_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
+##                              Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasSgemm, (UInt32, UInt32, UInt32,
-                Csize_t, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
-                cl.CL_mem, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t))
+## @api.blas_func2(clblasSgemm, (UInt32, UInt32, UInt32,
+##                 Csize_t, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t,
+##                 cl.CL_mem, Csize_t, Csize_t, cl.CL_float, cl.CL_mem, Csize_t, Csize_t))
 
-macro blas_gemm(func, arrType, mulType)
-    quote
-        function $(esc(func))( at::UInt32, bt::UInt32,
-                alpha::$mulType, A::@compat(Union{$arrType, Future}),
-                B::@compat(Union{$arrType, Future}), beta::$mulType, C::@compat(Union{$arrType, Future}))
+## macro blas_gemm(func, arrType, mulType)
+##     quote
+##         function $(esc(func))( at::UInt32, bt::UInt32,
+##                 alpha::$mulType, A::@compat(Union{$arrType, Future}),
+##                 B::@compat(Union{$arrType, Future}), beta::$mulType, C::@compat(Union{$arrType, Future}))
 
 
-            futures = to_futures(A, B, C)
-            m = convert(Csize_t, futures[1].dims[1])
-            n = convert(Csize_t, futures[2].dims[2])
-            k = convert(Csize_t, futures[1].dims[2])
+##             futures = to_futures(A, B, C)
+##             m = convert(Csize_t, futures[1].dims[1])
+##             n = convert(Csize_t, futures[2].dims[2])
+##             k = convert(Csize_t, futures[1].dims[2])
 
-            ctx   = futures[3].ctx
-            queue = futures[3].queue
-            req_num_events, events = getEvents(futures)
-            future_to_return = Future(ctx, queue, futures[3].mem, futures[3].dims)
+##             ctx   = futures[3].ctx
+##             queue = futures[3].queue
+##             req_num_events, events = getEvents(futures)
+##             future_to_return = Future(ctx, queue, futures[3].mem, futures[3].dims)
 
-            lda = m
-            ldb = k
-            ldc = m
+##             lda = m
+##             ldb = k
+##             ldc = m
 
-            $(esc(func))(uint32(1), at, bt,
-                        m, n, k,
-                        alpha, pointer(futures[1].mem), 0, lda,
-                        pointer(futures[2].mem), 0, ldb, beta,
-                        pointer(futures[3].mem), 0, ldc,
-                        uint32(1), [pointer(queue)],
-                        req_num_events,
-                        events,
-                        future_to_return.event)
+##             $(esc(func))(uint32(1), at, bt,
+##                         m, n, k,
+##                         alpha, pointer(futures[1].mem), 0, lda,
+##                         pointer(futures[2].mem), 0, ldb, beta,
+##                         pointer(futures[3].mem), 0, ldc,
+##                         uint32(1), [pointer(queue)],
+##                         req_num_events,
+##                         events,
+##                         future_to_return.event)
 
-            return future_to_return
-         end
-    end
-end
+##             return future_to_return
+##          end
+##     end
+## end
 
-@blas_gemm(clblasSgemm, Array{cl.CL_float}, cl.CL_float)
+## @blas_gemm(clblasSgemm, Array{cl.CL_float}, cl.CL_float)
 
-@api.blas_func(clblasDgemm, (UInt32, UInt32, UInt32,
-              Csize_t, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
-              cl.CL_mem, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
-              cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
-              Ptr{cl.CL_event}))
+## @api.blas_func(clblasDgemm, (UInt32, UInt32, UInt32,
+##               Csize_t, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
+##               cl.CL_mem, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
+##               cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
+##               Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasDgemm, (UInt32, UInt32, UInt32,
-              Csize_t, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
-              cl.CL_mem, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t))
+## @api.blas_func2(clblasDgemm, (UInt32, UInt32, UInt32,
+##               Csize_t, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t,
+##               cl.CL_mem, Csize_t, Csize_t, cl.CL_double, cl.CL_mem, Csize_t, Csize_t))
 
-@api.blas_func(clblasCgemm, (UInt32, UInt32, UInt32,
-            Csize_t, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
-            cl.CL_mem, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
-            cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
-            Ptr{cl.CL_event}))
+## @api.blas_func(clblasCgemm, (UInt32, UInt32, UInt32,
+##             Csize_t, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
+##             cl.CL_mem, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
+##             cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
+##             Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasCgemm, (UInt32, UInt32, UInt32,
-            Csize_t, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
-            cl.CL_mem, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t))
+## @api.blas_func2(clblasCgemm, (UInt32, UInt32, UInt32,
+##             Csize_t, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t,
+##             cl.CL_mem, Csize_t, Csize_t, FloatComplex, cl.CL_mem, Csize_t, Csize_t))
 
-@api.blas_func(clblasZgemm, (UInt32, UInt32, UInt32,
-              Csize_t, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
-              cl.CL_mem, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
-              cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
-              Ptr{cl.CL_event}))
+## @api.blas_func(clblasZgemm, (UInt32, UInt32, UInt32,
+##               Csize_t, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
+##               cl.CL_mem, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
+##               cl.cl_uint, Ptr{cl.CL_command_queue}, cl.CL_uint, Ptr{cl.CL_event},
+##               Ptr{cl.CL_event}))
 
-@api.blas_func2(clblasZgemm, (UInt32, UInt32, UInt32,
-              Csize_t, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
-              cl.CL_mem, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t))
+## @api.blas_func2(clblasZgemm, (UInt32, UInt32, UInt32,
+##               Csize_t, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t,
+##               cl.CL_mem, Csize_t, Csize_t, DoubleComplex, cl.CL_mem, Csize_t, Csize_t))
 
 
 
@@ -87,8 +87,31 @@ for (func, typ) in [(:clblasSgemm, cl.CL_float),
                     (:clblasDgemm, cl.CL_double),
                     (:clblasCgemm, CL_float2),
                     (:clblasZgemm, CL_double2)]
+
+    ## @eval @blasfun $func(order::UInt32,
+    ##                      transA::UInt32, transB::UInt32,
+    ##                      M::Csize_t, N::Csize_t, K::Csize_t,
+    ##                      alpha::$typ,
+    ##                      A::cl.CL_mem, offA::Csize_t, lda::Csize_t,
+    ##                      B::cl.CL_mem, offB::Csize_t, ldb::Csize_t,
+    ##                      beta::$typ,
+    ##                      C::cl.CL_mem, offC::Csize_t, ldc::Csize_t,
+    ##                      n_queues::cl.CL_uint,
+    ##                      queues::Ptr{cl.CL_command_queue},
+    ##                      n_events_in_wait_list::cl.CL_uint,
+    ##                      event_wait_list::Ptr{cl.CL_event},
+    ##                      events::Ptr{cl.CL_event})
+
+    ## @eval @blasfun2 $func(order::UInt32,
+    ##                       transA::UInt32, transB::UInt32,
+    ##                       M::Csize_t, N::Csize_t, K::Csize_t,
+    ##                       alpha::$typ,
+    ##                       A::cl.CL_mem, offA::Csize_t, lda::Csize_t,
+    ##                       B::cl.CL_mem, offB::Csize_t, ldb::Csize_t,
+    ##                       beta::$typ,
+    ##                       C::cl.CL_mem, offC::Csize_t, ldc::Csize_t)
     
-    @eval @api2.blasfun $func(order::UInt32,
+    @eval @blasfun $func(order::clblasOrder,
                               transA::clblasTranspose, transB::clblasTranspose,
                               M::Csize_t, N::Csize_t, K::Csize_t,
                               alpha::$typ,
@@ -102,7 +125,7 @@ for (func, typ) in [(:clblasSgemm, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::UInt32,
+    @eval @blasfun2 $func(order::clblasOrder,
                                transA::clblasTranspose, transB::clblasTranspose,
                                M::Csize_t, N::Csize_t, K::Csize_t,
                                alpha::$typ,

--- a/src/L3/HEMM.jl
+++ b/src/L3/HEMM.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasChemm, CL_float2),
                     (:clblasZhemm, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun $func(order::clblasOrder, side::clblasSide,
                               uplo::clblasUplo,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
@@ -16,7 +16,7 @@ for (func, typ) in [(:clblasChemm, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun2 $func(order::clblasOrder, side::clblasSide,
                                uplo::clblasUplo,
                                M::Csize_t, N::Csize_t,
                                alpha::$typ,

--- a/src/L3/HER2K.jl
+++ b/src/L3/HER2K.jl
@@ -2,7 +2,7 @@
 for (func, typ, complex_typ) in [(:clblasCher2k, cl.CL_float, CL_float2),
                                  (:clblasZher2k, cl.CL_double, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose,
                               N::Csize_t, K::Csize_t,
                               alpha::$complex_typ,
@@ -16,7 +16,7 @@ for (func, typ, complex_typ) in [(:clblasCher2k, cl.CL_float, CL_float2),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose,
                                N::Csize_t, K::Csize_t,
                                alpha::$complex_typ,

--- a/src/L3/HERK.jl
+++ b/src/L3/HERK.jl
@@ -2,7 +2,7 @@
 for (func, typ) in [(:clblasCherk, cl.CL_float),
                     (:clblasZherk, cl.CL_double)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               trans::clblasTranspose,
                               N::Csize_t, K::Csize_t,
                               alpha::$typ,
@@ -15,7 +15,7 @@ for (func, typ) in [(:clblasCherk, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                trans::clblasTranspose,
                                N::Csize_t, K::Csize_t,
                                alpha::$typ,

--- a/src/L3/SYMM.jl
+++ b/src/L3/SYMM.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasSsymm, cl.CL_float),
                     (:clblasCsymm, CL_float2),
                     (:clblasZsymm, CL_double2)]
 
-    @eval @api2.blasfun $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun $func(order::clblasOrder, side::clblasSide,
                               uplo::clblasUplo,
                               M::Csize_t, N::Csize_t,
                               alpha::$typ,
@@ -18,7 +18,7 @@ for (func, typ) in [(:clblasSsymm, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun2 $func(order::clblasOrder, side::clblasSide,
                                uplo::clblasUplo,
                                M::Csize_t, N::Csize_t,
                                alpha::$typ,

--- a/src/L3/SYR2K.jl
+++ b/src/L3/SYR2K.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasSsyr2k, cl.CL_float),
                     (:clblasCsyr2k, CL_float2),
                     (:clblasZsyr2k, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               transAB::clblasTranspose,
                               N::Csize_t, K::Csize_t,
                               alpha::$typ,
@@ -18,7 +18,7 @@ for (func, typ) in [(:clblasSsyr2k, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                transAB::clblasTranspose,
                                N::Csize_t, K::Csize_t,
                                alpha::$typ,

--- a/src/L3/SYRK.jl
+++ b/src/L3/SYRK.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasSsyrk, cl.CL_float),
                     (:clblasCsyrk, CL_float2),
                     (:clblasZsyrk, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun $func(order::clblasOrder, uplo::clblasUplo,
                               transA::clblasTranspose,
                               N::Csize_t, K::Csize_t,
                               alpha::$typ,
@@ -17,7 +17,7 @@ for (func, typ) in [(:clblasSsyrk, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
+    @eval @blasfun2 $func(order::clblasOrder, uplo::clblasUplo,
                                transA::clblasTranspose,
                                N::Csize_t, K::Csize_t,
                                alpha::$typ,

--- a/src/L3/TRMM.jl
+++ b/src/L3/TRMM.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasStrmm, cl.CL_float),
                     (:clblasCtrmm, CL_float2),
                     (:clblasZtrmm, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun $func(order::clblasOrder, side::clblasSide,
                               uplo::clblasUplo, transA::clblasTranspose,
                               diag::clblasDiag,
                               M::Csize_t, N::Csize_t,
@@ -17,7 +17,7 @@ for (func, typ) in [(:clblasStrmm, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun2 $func(order::clblasOrder, side::clblasSide,
                                uplo::clblasUplo, transA::clblasTranspose,
                                diag::clblasDiag,
                                M::Csize_t, N::Csize_t,

--- a/src/L3/TRSM.jl
+++ b/src/L3/TRSM.jl
@@ -4,7 +4,7 @@ for (func, typ) in [(:clblasStrsm, cl.CL_float),
                     (:clblasCtrsm, CL_float2),
                     (:clblasZtrsm, CL_double2)]
     
-    @eval @api2.blasfun $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun $func(order::clblasOrder, side::clblasSide,
                               uplo::clblasUplo, transA::clblasTranspose,
                               diag::clblasDiag,
                               M::Csize_t, N::Csize_t,
@@ -17,7 +17,7 @@ for (func, typ) in [(:clblasStrsm, cl.CL_float),
                               event_wait_list::Ptr{cl.CL_event},
                               events::Ptr{cl.CL_event})
 
-    @eval @api2.blasfun2 $func(order::clblasOrder, side::clblasSide,
+    @eval @blasfun2 $func(order::clblasOrder, side::clblasSide,
                                uplo::clblasUplo, transA::clblasTranspose,
                                diag::clblasDiag,
                                M::Csize_t, N::Csize_t,

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -1,0 +1,60 @@
+
+import OpenCL.CLArray
+
+#### common stuff
+
+# TODO: is this conversion valid?
+Base.convert(::Type{CL_float2}, x::Complex{Float32}) =
+    CL_double2(real(x), imag(x))
+
+Base.convert(::Type{CL_double2}, x::Complex{Float64}) =
+    CL_double2(real(x), imag(x))
+
+
+function transval(t::Char)
+    return t == 'T' ? clblasTrans : clblasNoTrans
+end
+
+
+########################### L1 functions ###############################
+
+## AXPY
+for (func, typ) in [(:clblasSaxpy, Float32), (:clblasDaxpy, Float64),
+                    (:clblasCaxpy, CL_float2), (:clblasZaxpy, CL_double2)]
+
+    @eval function axpy!(alpha::$typ, x::CLArray{$typ,1}, y::CLArray{$typ,1};
+                         queue=cl.queue(x))
+        @assert length(x) == length(y) "x and y have different sizes"
+        $func(Csize_t(length(x)), alpha,
+                    bufptr(x), Csize_t(0), Cint(1),
+                    bufptr(y), Csize_t(0), Cint(1), [queue])
+    end
+
+end
+
+
+
+
+########################### L2 functions ###############################
+
+
+
+########################### L3 functions ###############################
+
+## GEMM
+for (func, typ) in [(:clblasSgemm, Float32), (:clblasDgemm, Float64),
+                    (:clblasCgemm, CL_float2), (:clblasZgemm, CL_double2)]
+    
+    @eval function gemm!(tA::Char, tB::Char,
+                         alpha::$typ, A::CLArray{$typ,2}, B::CLArray{$typ,2},
+                         beta::$typ, C::CLArray{$typ,2};
+                         queue=cl.queue(A))
+        M = UInt64(size(A)[1])
+        N = UInt64(size(B)[2])
+        K = UInt64(size(A)[2])
+        $func(clblasColumnMajor, transval(tA), transval(tB), M, N, K,
+              alpha, cl.bufptr(A), UInt(0), M, cl.bufptr(B), UInt(0), K,
+              beta, cl.bufptr(C), UInt(0), M, [queue])
+    end
+    
+end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,15 +1,3 @@
-module api2
-
-# including CL_float2 and CL_double2 types
-include("constants.jl")
-
-import OpenCL
-const cl = OpenCL
-
-
-## @unix_only const libCLBLAS = "libclBLAS"
-## @windows_only const libCLBLAS = "clBLAS"
-
 
 function parse_fun_expr(ex)
     if !(ex.head == :call)
@@ -136,5 +124,3 @@ macro blasfun2(expr)
     return esc(ex)
 end
 
-
-end


### PR DESCRIPTION
This is the beginning of high-level API. Just few functions are implemented, but I'd like to merge it early since it introduces some breaking changes. In particular: 

 * I removed internal `api2` module. The reason is that in combination with escaped code in macros and internal types that need to be used in 2 modules it makes a total mess. Making a flat structure simplifies things a lot (4 days vs 20 minutes of development for old and new structure). 
 * I also removed future-based API for `GEMM` functions, because it was conflicting with new high-level API. It might be possible to return them back, so please, let me know if you still use it. 

Example of HL API:

```
import OpenCL.CLArray
import CLBLAS
const clblas = CLBLAS                                                                                                                                           
const cl = clblas.cl

clblas.setup()
device, ctx, queue = clblas.get_next_compute_context()
alpha = 1.0
beta = 0.0

hA = rand(5, 10)                                                                                                                                            
hB = rand(10, 5)
A = CLArray(ctx, hA; queue=queue)
B = CLArray(ctx, hB; queue=queue)
C = cl.zeros(queue, 5, 5)

clblas.gemm!('N', 'N', alpha, A, B, beta, C)
cl.to_host(C)
hA * hB   # note values
```