### PR TITLE
cl.release! was deprecated in OpenCL.jl PR 80

### DIFF
--- a/src/CLBLAS.jl
+++ b/src/CLBLAS.jl
@@ -90,8 +90,8 @@ end
 function release!(compute_context_holder::Vector{Tuple})
     for (dev, ctx, queue) in compute_context_holder
         try
-            cl.release!(queue)
-            cl.release!(ctx)
+            finalize(queue)
+            finalize(ctx)
         catch err
             println(err)
             continue


### PR DESCRIPTION
Same as #14, but with latest updates from master. 