### PR TITLE
Simplified API  + few tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *~
+.juliahistory

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,68 @@
 language: julia
+
 os:
   - linux
+
 julia:
-  - release
+  - 0.4
+  - nightly
+
 notifications:
   email: false
+
 before_install:
-  - if [ `uname` = "Linux" ]; then
-      sudo apt-get update -qq -y;
-      sudo apt-get install -qq fglrx opencl-headers;
-      wget https://github.com/clMathLibraries/clBLAS/releases/download/v2.6/clBLAS-2.6.0-Linux-x64.tar.gz;
-      tar -xf clBLAS-2.6.0-Linux-x64.tar.gz;
-      export LD_LIBRARY_PATH=/home/travis/build/JuliaGPU/CLBLAS.jl/clBLAS-2.6.0-Linux-x64/lib64:${LD_LIBRARY_PATH};
-    fi;
-  # - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+  - which julia
+  # - if [ $TRAVIS_OS_NAME = "linux" ]; then
+  - wget http://developer.amd.com/amd-license-agreement-appsdk/ --post-data "amd_developer_central_nonce=a244523dae&_wp_http_referer=/amd-license-agreement-appsdk/&f=QU1ELUFQUC1TREtJbnN0YWxsZXItdjMuMC4xMzAuMTM1LUdBLWxpbnV4NjQudGFyLmJ6Mg==" -O AMD-SDK.tar.bz2;
+  - ls;  
+  - tar -xjf AMD-SDK.tar.bz2;
+  - ls;
+  - mkdir AMD-APP-SDK;
+  - sh AMD-APP-SDK*.sh --tar -xf -C /home/travis/build/JuliaGPU/CLBLAS.jl/AMD-APP-SDK;
+  - export LD_LIBRARY_PATH=/home/travis/build/JuliaGPU/CLBLAS.jl/AMD-APP-SDK/lib/x86_64:${LD_LIBRARY_PATH};
+  #   fi;
+  - ls /home/travis/build/JuliaGPU/CLBLAS.jl;
+  - ls /home/travis/build/JuliaGPU/CLBLAS.jl/AMD-APP-SDK;
+  - ls /home/travis/build/JuliaGPU/CLBLAS.jl/AMD-APP-SDK/lib;
+  - ls /home/travis/build/JuliaGPU/CLBLAS.jl/AMD-APP-SDK/lib/x86_64;
+  - wget https://github.com/clMathLibraries/clBLAS/releases/download/v2.6/clBLAS-2.6.0-Linux-x64.tar.gz;
+  - tar -xf clBLAS-2.6.0-Linux-x64.tar.gz;
+  - export LD_LIBRARY_PATH=/home/travis/build/JuliaGPU/CLBLAS.jl/clBLAS-2.6.0-Linux-x64/lib64:${LD_LIBRARY_PATH};
+  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 
 script:
-  - cd ${TRAVIS_BUILD_DIR}
-  - julia -e 'Pkg.add("OpenCL"); Pkg.checkout("OpenCL")'
-  - julia -e 'Pkg.add("CLBLAS"); Pkg.checkout("CLBLAS")'
-  # - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("CLBLAS"))`); Pkg.pin("CLBLAS"); Pkg.resolve()'
-  - julia test/runtests.jl
+  - julia -e 'Pkg.init(); Pkg.clone(pwd())'
+  - julia -e 'Pkg.checkout("OpenCL");'
+  - julia -e 'using CLBLAS; @assert isdefined(:CLBLAS); @assert typeof(CLBLAS) === Module'
+
+  - sudo -E /home/travis/julia/bin/julia -e "Pkg.test(\"OpenCL\")"
+  # - sudo -E /home/travis/julia/bin/julia -e "Pkg.test(\"CLBLAS\")"
+  # - julia test/runtests.jl
+
+
+after_success:
+  - julia -e 'Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'; fi
+
+# language: julia
+# os:
+#   - linux
+# julia:
+#   - release
+# notifications:
+#   email: false
+# before_install:
+#   - if [ `uname` = "Linux" ]; then
+#       sudo apt-get update -qq -y;
+#       sudo apt-get install -qq fglrx opencl-headers;
+#       wget https://github.com/clMathLibraries/clBLAS/releases/download/v2.6/clBLAS-2.6.0-Linux-x64.tar.gz;
+#       tar -xf clBLAS-2.6.0-Linux-x64.tar.gz;
+#       export LD_LIBRARY_PATH=/home/travis/build/JuliaGPU/CLBLAS.jl/clBLAS-2.6.0-Linux-x64/lib64:${LD_LIBRARY_PATH};
+#     fi;
+#   # - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+
+# script:
+#   - cd ${TRAVIS_BUILD_DIR}
+#   - julia -e 'Pkg.add("OpenCL"); Pkg.checkout("OpenCL")'
+#   - julia -e 'Pkg.add("CLBLAS"); Pkg.checkout("CLBLAS")'
+#   # - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("CLBLAS"))`); Pkg.pin("CLBLAS"); Pkg.resolve()'
+#   - julia test/runtests.jl

--- a/src/CLBLAS.jl
+++ b/src/CLBLAS.jl
@@ -1,6 +1,8 @@
 
 module CLBLAS
 
+export axpy!, scal!, gemm!
+
 # why there is a type assertion at context.jl line 38
 import OpenCL
 const cl = OpenCL
@@ -11,7 +13,7 @@ using Compat
 @windows_only const libCLBLAS = "clBLAS"
 
 include("constants.jl")
-include("macros.jl")   
+include("macros.jl")
 
 include("L1/L1.jl")
 include("L2/L2.jl")
@@ -100,4 +102,3 @@ function release!(compute_context_holder::Vector{Tuple})
 end
 
 end # module
-   

--- a/src/L1/AXPY.jl
+++ b/src/L1/AXPY.jl
@@ -1,56 +1,56 @@
 
 @blasfun clblasSaxpy(n::Csize_t, alpha::cl.CL_float,
-                          X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                          Y::cl.CL_mem, offy::Csize_t, incy::Cint,
-                          n_queues::cl.CL_uint,
-                          queues::Ptr{cl.CL_command_queue},
-                          n_events_in_wait_list::cl.CL_uint,
-                          event_wait_list::Ptr{cl.CL_event},
-                          events::Ptr{cl.CL_event})
-
+                     X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                     Y::cl.CL_mem, offy::Csize_t, incy::Cint,
+                     n_queues::cl.CL_uint,
+                     queues::Ptr{cl.CL_command_queue},
+                     n_events_in_wait_list::cl.CL_uint,
+                     event_wait_list::Ptr{cl.CL_event},
+                     events::Ptr{cl.CL_event})
+                     
 @blasfun2 clblasSaxpy(n::Csize_t, alpha::cl.CL_float,
-                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                           Y::cl.CL_mem, offy::Csize_t, incy::Cint)
-
-
+                      X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                      Y::cl.CL_mem, offy::Csize_t, incy::Cint)
+                      
+                      
 @blasfun clblasDaxpy(n::Csize_t, alpha::cl.CL_double,
-                          X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                          Y::cl.CL_mem, offy::Csize_t, incy::Cint,
-                          n_queues::cl.CL_uint,
-                          queues::Ptr{cl.CL_command_queue},
-                          n_events_in_wait_list::cl.CL_uint,
-                          event_wait_list::Ptr{cl.CL_event},
-                          events::Ptr{cl.CL_event})
-
+                     X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                     Y::cl.CL_mem, offy::Csize_t, incy::Cint,
+                     n_queues::cl.CL_uint,
+                     queues::Ptr{cl.CL_command_queue},
+                     n_events_in_wait_list::cl.CL_uint,
+                     event_wait_list::Ptr{cl.CL_event},
+                     events::Ptr{cl.CL_event})
+                          
 @blasfun2 clblasDaxpy(n::Csize_t, alpha::cl.CL_double,
-                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                           Y::cl.CL_mem, offy::Csize_t, incy::Cint)
+                      X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                      Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 
 
 @blasfun clblasCaxpy(n::Csize_t, alpha::CL_float2,
-                          X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                          Y::cl.CL_mem, offy::Csize_t, incy::Cint,
-                          n_queues::cl.CL_uint,
-                          queues::Ptr{cl.CL_command_queue},
-                          n_events_in_wait_list::cl.CL_uint,
-                          event_wait_list::Ptr{cl.CL_event},
-                          events::Ptr{cl.CL_event})
+                     X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                     Y::cl.CL_mem, offy::Csize_t, incy::Cint,
+                     n_queues::cl.CL_uint,
+                     queues::Ptr{cl.CL_command_queue},
+                     n_events_in_wait_list::cl.CL_uint,
+                     event_wait_list::Ptr{cl.CL_event},
+                     events::Ptr{cl.CL_event})
 
 @blasfun2 clblasCaxpy(n::Csize_t, alpha::CL_float2,
-                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                           Y::cl.CL_mem, offy::Csize_t, incy::Cint)
+                      X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                      Y::cl.CL_mem, offy::Csize_t, incy::Cint)
                            
 
 @blasfun clblasZaxpy(n::Csize_t, alpha::CL_double2,
-                          X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                          Y::cl.CL_mem, offy::Csize_t, incy::Cint,
-                          n_queues::cl.CL_uint,
-                          queues::Ptr{cl.CL_command_queue},
-                          n_events_in_wait_list::cl.CL_uint,
-                          event_wait_list::Ptr{cl.CL_event},
-                          events::Ptr{cl.CL_event})
+                     X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                     Y::cl.CL_mem, offy::Csize_t, incy::Cint,
+                     n_queues::cl.CL_uint,
+                     queues::Ptr{cl.CL_command_queue},
+                     n_events_in_wait_list::cl.CL_uint,
+                     event_wait_list::Ptr{cl.CL_event},
+                     events::Ptr{cl.CL_event})
 
 @blasfun2 clblasZaxpy(n::Csize_t, alpha::CL_double2,
-                           X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                           Y::cl.CL_mem, offy::Csize_t, incy::Cint)
+                      X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                      Y::cl.CL_mem, offy::Csize_t, incy::Cint)
 

--- a/src/L1/SCAL.jl
+++ b/src/L1/SCAL.jl
@@ -4,15 +4,15 @@ for (func, typ) in [(:clblasSscal, cl.CL_float),
                     (:clblasCscal, CL_float2),
                     (:clblasZscal, CL_double2)]
     
-    @eval @blasfun $func(N::Csize_t, alpha::CL_double2,
-                              X::cl.CL_mem, offx::Csize_t, incx::Cint,
-                              n_queues::cl.CL_uint,
-                              queues::Ptr{cl.CL_command_queue},
-                              n_events_in_wait_list::cl.CL_uint,
-                              event_wait_list::Ptr{cl.CL_event},
-                              events::Ptr{cl.CL_event})
-
-    @eval @blasfun2 $func(N::Csize_t, alpha::CL_double2,
-                               X::cl.CL_mem, offx::Csize_t, incx::Cint)
+    @eval @blasfun $func(N::Csize_t, alpha::$typ,
+                         X::cl.CL_mem, offx::Csize_t, incx::Cint,
+                         n_queues::cl.CL_uint,
+                         queues::Ptr{cl.CL_command_queue},
+                         n_events_in_wait_list::cl.CL_uint,
+                         event_wait_list::Ptr{cl.CL_event},
+                         events::Ptr{cl.CL_event})
+    
+    @eval @blasfun2 $func(N::Csize_t, alpha::$typ,
+                          X::cl.CL_mem, offx::Csize_t, incx::Cint)
     
 end

--- a/src/highlevel.jl
+++ b/src/highlevel.jl
@@ -1,5 +1,6 @@
 
 import OpenCL.CLArray
+import Base.LinAlg.BLAS: axpy!, scal!, gemm!
 
 #### common stuff
 
@@ -24,6 +25,20 @@ for (func, typ) in [(:clblasSaxpy, Float32), (:clblasDaxpy, Float64),
 
 end
 
+
+## SCAL
+for (func, typ) in [(:clblasSscal, Float32), (:clblasDscal, Float64),
+                    (:clblasCscal, CL_float2), (:clblasZscal, CL_double2)]
+
+    @eval function scal!(n::Integer, DA::$typ,
+                         DX::CLArray{$typ}, incx::Integer;
+                         queue=cl.queue(DX))
+        return $func(Csize_t(n), DA,
+                     pointer(DX), Csize_t(0), Cint(incx),
+                     [queue])
+    end
+
+end
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,15 @@
 
+import OpenCL: CLArray
+const cl = OpenCL
 using CLBLAS
+
 
 CLBLAS.setup()
 
-@assert 1 == 1
+dev, ctx, q = cl.create_compute_context()
+
+include("test_l1.jl")
+
+include("test_l3.jl")
+
+println("Ok.")

--- a/test/test_l1.jl
+++ b/test/test_l1.jl
@@ -1,0 +1,41 @@
+
+# axpy
+for typ in [Float32,
+            Float64,
+            # Complex64,
+            Complex128]
+    @eval begin
+        T = $typ
+        alpha = T(2.0)
+        hx = rand(T, 32)        
+        hy = rand(T, 32)
+        x = CLArray(q, hx)
+        y = CLArray(q, hy)
+
+        cl.wait(axpy!(alpha, x, y; queue=q))
+        axpy!(alpha, hx, hy)
+        
+        @assert isapprox(cl.to_host(y), hy)
+    end
+end
+
+# scal
+for typ in [Float32,
+            Float64,
+            # Complex64,
+            Complex128]
+    
+    @eval begin
+        n = 32
+        DA = $typ(2.0)
+        hDX = rand($typ, 32)
+        DX = CLArray(q, hDX)
+        incx = 1
+        
+        cl.wait(scal!(n, DA, DX, incx; queue=q))
+        scal!(n, DA, hDX, incx)
+        
+        @assert isapprox(cl.to_host(DX), hDX)
+    end
+end
+

--- a/test/test_l3.jl
+++ b/test/test_l3.jl
@@ -1,0 +1,23 @@
+
+# gemm
+for typ in [Float32,
+            Float64,
+            # Complex64,
+            Complex128]
+    @eval begin
+        T = $typ
+        alpha = T(2.0)
+        beta = T(0.0)
+        hA = rand(T, 64, 32)        
+        hB = rand(T, 32, 64)
+        hC = rand(T, 64, 64)
+        A = CLArray(q, hA)
+        B = CLArray(q, hB)
+        C = CLArray(q, hC)
+        
+        cl.wait(gemm!('N', 'N', alpha, A, B, beta, C; queue=q))
+        gemm!('N', 'N', alpha, hA, hB, beta, hC)
+        
+        @assert isapprox(cl.to_host(C), hC)
+    end
+end


### PR DESCRIPTION
1. **Simplified macros** for wrapping CLBLAS functions
2. Several **tests** for high-level API

I've encountered 2 issues that I couldn't resolve quickly, so I'm going to work on them separately. Here are these issues (in case somebody has an idea how to fix them):

1. **Tests on Travis don't work.** With new docker infrastructure installing OpenCL in tests using `fglrx` doesn't work any more, so as suggested by @vchuravy we need to download either AMD or Intel OpenCL implementation. I made a script for AMD SDK just yesterday, but today it stopped working without any meaningful reason. Current plan is to try Intel implementation first and, if no success, just upload OpenCL to Dropbox or something like that. 

2. **CLBLAS functions don't work for `Complex{Float32}`**. There might be some difference between internal representation of `Complex64` in Julia and `cl_float2` in C (field alignment?) or just improper call, but as a matter of fact calling CLBLAS functions with `Complex64` results in a segfault in `libclBLAS.so`. Interestingly, `Complex128` works perfectly well. 
