### PR TITLE
change homebrew/science to homebrew/core

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,4 @@
 using BinDeps
-using Compat
 
 @BinDeps.setup
 libnames = ["libCLBLAS", "clBLAS", "libclBLAS"]
@@ -37,7 +36,7 @@ end
 
 if is_apple()
     using Homebrew
-    provides(Homebrew.HB, "homebrew/science/clblas", libCLBLAS, os = :Darwin)
+    provides(Homebrew.HB, "homebrew/core/clblas", libCLBLAS, os = :Darwin)
 end
 
 @BinDeps.install Dict("libCLBLAS" => "libCLBLAS")


### PR DESCRIPTION
This tap was moved, CLBLAS fails to build on my mac without this, succeeds with it.
